### PR TITLE
FIX: Backgroundanimation

### DIFF
--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -46,6 +46,7 @@ const Name = styled.h1`
   margin: 0;
   width: auto;
   user-select: text;
+  pointer-events: none;
   .wf-active & {
     font-family: 'Montserrat', sans-serif;
   }


### PR DESCRIPTION
With the curser over "Dustin Schau" the the pointer-event gets caught and the background animation breaks. I hope I picket the right place for the correction. works when i do it in chrome inline. but didn't test it with the source. 